### PR TITLE
formalism: Fill in auxiliary definitions and metatheorems for patterned let

### DIFF
--- a/formalism/patterned.tex
+++ b/formalism/patterned.tex
@@ -411,3 +411,71 @@ $\judgbox{\erase{\PCMV}}$ is a metafunction defined as follows:
   \erasesToRow{(\PCAsc{\PCMV}{\TMV})}{\PAsc{\erase{\PCMV}}{\TMV}} \\
   \erasesToRow{\PCInconType{\PCAsc{\PCMV}{\TMV}}}{\PAsc{\erase{\PCMV}}{\TMV}}
 \end{array}\]
+
+\subsubsection{Metatheorems}
+In addition to the original metatheorems above, the following ones governing patterns additionally
+hold.
+
+\begin{theorem}[name=Pattern Marking Totality] \
+  \begin{enumerate}
+    \item For all $\ctx$ and $\PMV$,
+      there exist $\PCMV$ and $\TMV$
+        such that $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}$.
+
+    \item For all $\ctx$, $\PMV$, and $\TMV$,
+      there exists $\PCMV$ and $\ctx'$
+        such that $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}{\ctx'}$.
+  \end{enumerate}
+\end{theorem}
+
+\begin{theorem}[name=Pattern Marking Well-Formedness] \
+  \begin{enumerate}
+    \item If $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}$,
+      then $\ctxSynPatM{\ctx}{\PCMV}{\TMV}$
+        and $\erasesTo{\PCMV}{\PMV}$.
+
+    \item If $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}{\ctx'}$,
+      then $\ctxAnaPatM{\ctx}{\PCMV}{\TMV}{\ctx'}$
+        and $\erasesTo{\PCMV}{\PMV}$.
+  \end{enumerate}
+\end{theorem}
+
+\begin{theorem}[name=Pattern Marking of Well-Typed/Ill-Typed Patterns] \
+  \begin{enumerate}
+    \item \begin{enumerate}
+        \item If $\ctxSynPatU{\ctx}{\PMV}{\TMV}$
+            and $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}$,
+          then $\markless{\PCMV}$.
+
+        \item If $\ctxAnaPatU{\ctx}{\PMV}{\TMV}{\ctx'}$
+            and $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV}{\ctx'}$,
+          then $\markless{\PCMV}$.
+      \end{enumerate}
+
+    \item \begin{enumerate}
+        \item If there does not exist $\TMV$
+            such that $\ctxSynPatU{\ctx}{\PMV}{\TMV}$,
+          then for all $\PCMV$ and $\TMV'$
+            such that $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV'}$,
+            it is not the case that $\markless{\PCMV}$.
+
+        \item If there does not exist $\TMV$ and $\ctx'$ such that $\ctxAnaPatU{\ctx}{\PMV}{\TMV}{\ctx'}$,
+          then for all $\PCMV$, $\TMV'$, and $\ctx'$
+            such that $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV}{\TMV'}{\ctx'}$,
+            it is not the case that $\markless{\PCMV}$.
+      \end{enumerate}
+  \end{enumerate}
+\end{theorem}
+
+\begin{theorem}[name=Pattern Marking Unicity] \
+  \begin{enumerate}
+    \item If $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV_1}{\TMV_1}$
+        and $\ctxSynFixedIntoPat{\ctx}{\PMV}{\PCMV_2}{\TMV_2}$,
+      then $\PCMV_1 = \PCMV_2$
+        and $\TMV_1 = \TMV_2$.
+
+    \item If $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV_1}{\TMV}{\ctx_1}$
+        and $\ctxAnaFixedIntoPat{\ctx}{\PMV}{\PCMV_2}{\TMV}{\ctx_2}$,
+      then $\PCMV_1 = \PCMV_2$ and $\ctx_1 = \ctx_2$.
+  \end{enumerate}
+\end{theorem}

--- a/formalism/patterned.tex
+++ b/formalism/patterned.tex
@@ -11,6 +11,43 @@
                                \mid \PCInconType{\PCMV} \mid \PCAnaNonMatchedProd{\PCMV}
 \end{array}\]
 
+\subsubsection{Types}
+\judgbox{\ensuremath{\consistent{\TMV_1}{\TMV_2}}} $\TMV_1$ is consistent with $\TMV_2$
+%
+\begin{mathpar}
+  \inferrule[TCUnknownSwitch1]{ }{
+    \consistent{\TUnknownSwitch}{\TMV}
+  }
+
+  \inferrule[TCUnknownSwitch2]{ }{
+    \consistent{\TMV}{\TUnknownSwitch}
+  }
+\end{mathpar}
+
+\judgbox{\ensuremath{\matchedArrow{\TMV}{\TMV_1}{\TMV_2}}} $\TMV$ has matched arrow type $\TArrow{\TMV_1}{\TMV_2}$
+%
+\begin{mathpar}
+  \inferrule[TMAUnknownSwitch]{ }{
+    \matchedArrow{\TUnknownSwitch}{\TUnknownSwitch}{\TUnknownSwitch}
+  }
+\end{mathpar}
+
+\judgbox{\ensuremath{\matchedProd{\TMV}{\TMV_1}{\TMV_2}}} $\TMV$ has matched binary product type $\TProd{\TMV_1}{\TMV_2}$
+%
+\begin{mathpar}
+  \inferrule[TMPUnknownSwitch]{ }{
+    \matchedProd{\TUnknownSwitch}{\TUnknownSwitch}{\TUnknownSwitch}
+  }
+\end{mathpar}
+
+\judgbox{\ensuremath{\TJoin{\TMV_1}{\TMV_2}}} is a \emph{partial} metafunction defined as follows:
+%
+\[\begin{array}{rcl}
+  & \vdots & \\
+  \joinsToRow{\TUnknownSwitch}{\TMV}{\TUnknownSwitch} \\
+  \joinsToRow{\TMV}{\TUnknownSwitch}{\TUnknownSwitch}
+\end{array}\]
+
 \subsubsection{Unmarked expressions}
 \judgbox{\ctxSynTypeU{\ctx}{\EMV}{\TMV}} $\EMV$ synthesizes type $\TMV$
 %
@@ -43,6 +80,14 @@
     \ctxAnaTypeU{\ctx'}{\EMV_{2}}{\TMV_2}
   }{
     \ctxAnaTypeU{\ctx}{\ELet{\PMV}{\EMV_{1}}{\EMV_{2}}}{\TMV_2}
+  }
+\end{mathpar}
+
+\judgbox{\subsumable{\EMV}} $\EMV$ is subsumable
+%
+\begin{mathpar}
+  \inferrule[USuLetPat]{ }{
+    \subsumable{\ELet{\PMV}{\EMV_1}{\EMV_2}}
   }
 \end{mathpar}
 
@@ -103,6 +148,34 @@
     \ctxAnaTypeM{\ctx}{\ELet{\PCMV}{\ECMV_{1}}{\ECMV_{2}}}{\TMV_2}
   }
 \end{mathpar}
+
+\judgbox{\subsumable{\ECMV}} $\ECMV$ is subsumable
+%
+\begin{mathpar}
+  \inferrule[MSuLetPat]{ }{
+    \subsumable{\ECLet{\PMV}{\ECMV_1}{\ECMV_2}}
+  }
+\end{mathpar}
+
+\judgbox{\markless{\ECMV}} $\ECMV$ has no marks
+%
+\begin{mathpar}
+  \inferrule[MLLetPat]{
+    \markless{\PCMV} \\
+    \markless{\ECMV_1} \\
+    \markless{\ECMV_2}
+  }{
+    \markless{\ECLet{\PCMV}{\ECMV_1}{\ECMV_2}}
+  }
+\end{mathpar}
+
+\subsubsection{Mark erasure}
+$\judgbox{\erase{\ECMV}}$ is a metafunction defined as follows:
+%
+\[\begin{array}{rcl}
+  & \vdots & \\
+  \erasesToRow{(\ECLet{\PCMV}{\ECMV_1}{\ECMV_2})}{\ELet{\erase{\PCMV}}{\erase{\ECMV_1}}{\erase{\ECMV_2}}}
+\end{array}\]
 
 \subsubsection{Unmarked patterns}
 \judgbox{\ensuremath{\ctxSynPatU{\ctx}{\PMV}{\TMV}}} $\PMV$ synthesizes type $\TMV$
@@ -300,3 +373,41 @@
     \ctxAnaPatM{\ctx}{\PCInconType{\PCAsc{\PCMV}{\TMV'}}}{\TMV}{\ctx'}
   }
 \end{mathpar}
+
+\judgbox{\markless{\PCMV}} $\PCMV$ has no marks
+%
+\begin{mathpar}
+  \inferrule[MLPWild]{ }{
+    \markless{\PCWild}
+  }
+
+  \inferrule[MLPVar]{ }{
+    \markless{\PCVar{x}}
+  }
+
+  \inferrule[MLPPair]{
+    \markless{\PCMV_1} \\
+    \markless{\PCMV_2}
+  }{
+    \markless{\PCPair{\PCMV_1}{\PCMV_2}}
+  }
+
+  \inferrule[MLPAnn]{
+    \markless{\PCMV}
+  }{
+    \markless{\PCAsc{\PCMV}{\TMV}}
+  }
+\end{mathpar}
+
+\subsubsection{Pattern mark erasure}
+$\judgbox{\erase{\PCMV}}$ is a metafunction defined as follows:
+%
+\[\begin{array}{rcl}
+  & \vdots & \\
+  \erasesToRow{\PCWild}{\PWild} \\
+  \erasesToRow{\PCVar{x}}{\PVar{x}} \\
+  \erasesToRow{\PCPair{\PCMV_1}{\PCMV_2}}{\PPair{\erase{\PCMV_1}}{\erase{\PCMV_2}}} \\
+  \erasesToRow{\PCAnaNonMatchedProd{\PCPair{\PCMV_1}{\PCMV_2}}}{\PPair{\erase{\PCMV_1}}{\erase{\PCMV_2}}} \\
+  \erasesToRow{(\PCAsc{\PCMV}{\TMV})}{\PAsc{\erase{\PCMV}}{\TMV}} \\
+  \erasesToRow{\PCInconType{\PCAsc{\PCMV}{\TMV}}}{\PAsc{\erase{\PCMV}}{\TMV}}
+\end{array}\]


### PR DESCRIPTION
Fills in the definitions of auxiliary judgments and such for patterns and patterned let expressions. Also gives the corresponding metatheorems for pattern marking.